### PR TITLE
Fix(api): handle Google Map stream errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,8 @@ Access control and timeouts live in shared middleware, not handlers
 - **No commits without explicit user approval** — AI edits → user reviews →
   user tests → user says "commit". Even with tests green, visual changes need
   user eyes before landing.
-- **One concern per commit**, message style per `git log`
-  (`Feat(xxx):` / `Fix(ui):` / `Refactor(xxx):` / `Style:` / `Chore:`),
+- **One concern per commit**, message style per commitlint
+  (`feat(xxx):` / `fix(ui):` / `refactor(xxx):` / `style:` / `chore:`),
   AI adds itself as co-author.
 - **Self-test before handing off** (`pnpm check`); if a change is visual and
   headless-unverifiable, say so explicitly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,8 @@ Access control and timeouts live in shared middleware, not handlers
 - **No commits without explicit user approval** — AI edits → user reviews →
   user tests → user says "commit". Even with tests green, visual changes need
   user eyes before landing.
-- **One concern per commit**, message style per commitlint
-  (`feat(xxx):` / `fix(ui):` / `refactor(xxx):` / `style:` / `chore:`),
+- **One concern per commit**, message style per `git log`
+  (`Feat(xxx):` / `Fix(ui):` / `Refactor(xxx):` / `Style:` / `Chore:`),
   AI adds itself as co-author.
 - **Self-test before handing off** (`pnpm check`); if a change is visual and
   headless-unverifiable, say so explicitly.

--- a/api/google-map.js
+++ b/api/google-map.js
@@ -40,6 +40,39 @@ const styles = {
     ]
 };
 
+const createRemainingBody = (reader) => {
+    let readerReleased = false;
+    const releaseReader = () => {
+        if (readerReleased) return;
+        reader.releaseLock();
+        readerReleased = true;
+    };
+
+    return new ReadableStream({
+        async pull(controller) {
+            try {
+                const { done, value } = await reader.read();
+                if (done) {
+                    releaseReader();
+                    controller.close();
+                    return;
+                }
+                controller.enqueue(value);
+            } catch (e) {
+                releaseReader();
+                controller.error(e);
+            }
+        },
+        async cancel(reason) {
+            try {
+                await reader.cancel(reason);
+            } finally {
+                releaseReader();
+            }
+        },
+    });
+};
+
 export default async (req, res) => {
     // Check if request is legitimate
     if (!isValidRequest(req)) {
@@ -71,22 +104,40 @@ export default async (req, res) => {
 
     const url = `https://maps.googleapis.com/maps/api/staticmap?center=${latitude},${longitude}&markers=color:blue%7C${latitude},${longitude}&scale=${scale}&zoom=${zoom}&maptype=roadmap&language=${language}&format=${fmt}&size=${mapSize}&style=${styleParam}&key=${apiKey}`;
 
-    // Unlike the JSON handlers, the Static Maps response is a binary JPEG
-    // and must be passed through to the client. Convert the WHATWG ReadableStream
-    // from fetch into a Node Readable and pipe it at the Express response.
+    let bodyReader;
     try {
         const apiRes = await fetchUpstream(url);
         if (!apiRes.ok) {
             return res.status(apiRes.status).json({ error: `Upstream map API returned ${apiRes.status}` });
         }
+
+        // Read one chunk before the response starts. An early upstream error can
+        // then return JSON instead of closing the client connection.
+        bodyReader = apiRes.body.getReader();
+        const firstChunk = await bodyReader.read();
+
         res.setHeader('Content-Type', apiRes.headers.get('content-type') || 'image/jpeg');
         // Binary streams bypass the res.json hook in the cacheable() middleware,
         // so apply the cache value it stashed on res.locals here on the 2xx path.
         if (res.locals.cacheControl) {
             res.setHeader('Cache-Control', res.locals.cacheControl);
         }
-        await pipeline(Readable.fromWeb(apiRes.body), res);
+
+        if (firstChunk.done) {
+            bodyReader.releaseLock();
+            bodyReader = undefined;
+            return res.end();
+        }
+
+        res.write(firstChunk.value);
+        const remainingBody = Readable.fromWeb(createRemainingBody(bodyReader));
+        bodyReader = undefined;
+        await pipeline(remainingBody, res);
     } catch (e) {
+        if (bodyReader) {
+            await bodyReader.cancel(e).catch(() => undefined);
+            bodyReader.releaseLock();
+        }
         logger.error({ err: e, latitude, longitude, language, CanvasMode }, 'google-map handler failed');
         if (res.headersSent || res.destroyed) {
             if (!res.destroyed) res.destroy();

--- a/api/google-map.js
+++ b/api/google-map.js
@@ -114,7 +114,26 @@ export default async (req, res) => {
         // Read one chunk before the response starts. An early upstream error can
         // then return JSON instead of closing the client connection.
         bodyReader = apiRes.body.getReader();
-        const firstChunk = await bodyReader.read();
+        let clientClosed = false;
+        const cancelFirstRead = () => {
+            clientClosed = true;
+            void bodyReader.cancel(new Error('client disconnected')).catch(() => undefined);
+        };
+        res.once('close', cancelFirstRead);
+        if (res.destroyed) cancelFirstRead();
+
+        let firstChunk;
+        try {
+            firstChunk = await bodyReader.read();
+        } finally {
+            res.off('close', cancelFirstRead);
+        }
+
+        if (clientClosed || res.destroyed) {
+            bodyReader.releaseLock();
+            bodyReader = undefined;
+            return;
+        }
 
         res.setHeader('Content-Type', apiRes.headers.get('content-type') || 'image/jpeg');
         // Binary streams bypass the res.json hook in the cacheable() middleware,

--- a/api/google-map.js
+++ b/api/google-map.js
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { fetchUpstream } from '../common/fetch-with-timeout.js';
 import logger from '../common/logger.js';
 
@@ -84,9 +85,13 @@ export default async (req, res) => {
         if (res.locals.cacheControl) {
             res.setHeader('Cache-Control', res.locals.cacheControl);
         }
-        Readable.fromWeb(apiRes.body).pipe(res);
+        await pipeline(Readable.fromWeb(apiRes.body), res);
     } catch (e) {
         logger.error({ err: e, latitude, longitude, language, CanvasMode }, 'google-map handler failed');
-        res.status(500).json({ error: e.message });
+        if (res.headersSent || res.destroyed) {
+            if (!res.destroyed) res.destroy();
+            return;
+        }
+        return res.status(500).json({ error: e.message });
     }
 };

--- a/tests/api-handlers.test.js
+++ b/tests/api-handlers.test.js
@@ -9,6 +9,8 @@
 // repeat those checks, so this file focuses on handler-specific branches.
 
 import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { Writable } from 'node:stream';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import configsHandler from '../api/configs.js';
@@ -64,6 +66,7 @@ const ENV_KEYS = [
     // Pre-rename spellings, still honored as fallbacks.
     'IPINFO_API_TOKEN', 'CLOUDFLARE_API',
 ];
+const originalFetch = globalThis.fetch;
 let envBackup = {};
 
 beforeEach(() => {
@@ -72,6 +75,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    globalThis.fetch = originalFetch;
     for (const k of ENV_KEYS) {
         if (envBackup[k] === undefined) delete process.env[k];
         else process.env[k] = envBackup[k];
@@ -120,6 +124,79 @@ describe('google-map handler', () => {
         }), res);
         assert.equal(res.statusCode, 400);
         assert.deepEqual(res.body, { error: 'Invalid request' });
+    });
+
+    it('stays active until the upstream image stream completes', async () => {
+        let closeBody;
+        const upstreamBody = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode('partial image'));
+                closeBody = () => controller.close();
+            },
+        });
+        globalThis.fetch = async () => new Response(upstreamBody, {
+            headers: { 'content-type': 'image/jpeg' },
+        });
+
+        const chunks = [];
+        const res = new Writable({
+            write(chunk, _encoding, callback) {
+                chunks.push(Buffer.from(chunk));
+                callback();
+            },
+        });
+        res.locals = {};
+        res.setHeader = () => res;
+        res.status = (code) => { res.statusCode = code; return res; };
+        res.json = (payload) => { res.body = payload; res.end(); return res; };
+
+        let settled = false;
+        const handlerPromise = googleMapHandler(createRequest({
+            query: { latitude: '1', longitude: '2', language: 'en' },
+        }), res).finally(() => { settled = true; });
+
+        await new Promise(setImmediate);
+        const settledBeforeClose = settled;
+        closeBody();
+        await handlerPromise;
+        if (!res.writableFinished) await once(res, 'finish');
+
+        assert.equal(settledBeforeClose, false);
+        assert.equal(Buffer.concat(chunks).toString(), 'partial image');
+    });
+
+    it('closes a partial image response when the upstream stream fails', async () => {
+        const upstreamBody = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode('partial image'));
+                setImmediate(() => controller.error(new Error('upstream reset')));
+            },
+        });
+        globalThis.fetch = async () => new Response(upstreamBody, {
+            headers: { 'content-type': 'image/jpeg' },
+        });
+
+        let headersSent = false;
+        let jsonCalled = false;
+        const res = new Writable({
+            write(_chunk, _encoding, callback) {
+                headersSent = true;
+                callback();
+            },
+        });
+        Object.defineProperty(res, 'headersSent', { get: () => headersSent });
+        res.locals = {};
+        res.setHeader = () => res;
+        res.status = (code) => { res.statusCode = code; return res; };
+        res.json = () => { jsonCalled = true; return res; };
+
+        await googleMapHandler(createRequest({
+            query: { latitude: '1', longitude: '2', language: 'en' },
+        }), res);
+
+        assert.equal(headersSent, true);
+        assert.equal(res.destroyed, true);
+        assert.equal(jsonCalled, false);
     });
 });
 

--- a/tests/api-handlers.test.js
+++ b/tests/api-handlers.test.js
@@ -165,6 +165,34 @@ describe('google-map handler', () => {
         assert.equal(Buffer.concat(chunks).toString(), 'partial image');
     });
 
+    it('returns 500 when the upstream stream fails before its first chunk', async () => {
+        const upstreamBody = new ReadableStream({
+            start(controller) {
+                controller.error(new Error('upstream reset'));
+            },
+        });
+        globalThis.fetch = async () => new Response(upstreamBody, {
+            headers: { 'content-type': 'image/jpeg' },
+        });
+
+        const res = new Writable({
+            write(_chunk, _encoding, callback) {
+                callback();
+            },
+        });
+        res.locals = {};
+        res.setHeader = () => res;
+        res.status = (code) => { res.statusCode = code; return res; };
+        res.json = (payload) => { res.body = payload; res.end(); return res; };
+
+        await googleMapHandler(createRequest({
+            query: { latitude: '1', longitude: '2', language: 'en' },
+        }), res);
+
+        assert.equal(res.statusCode, 500);
+        assert.deepEqual(res.body, { error: 'upstream reset' });
+    });
+
     it('closes a partial image response when the upstream stream fails', async () => {
         const upstreamBody = new ReadableStream({
             start(controller) {
@@ -197,6 +225,48 @@ describe('google-map handler', () => {
         assert.equal(headersSent, true);
         assert.equal(res.destroyed, true);
         assert.equal(jsonCalled, false);
+    });
+
+    it('cancels the upstream body when the client disconnects', async () => {
+        let closeTimer;
+        let bodyCancelled = false;
+        const upstreamBody = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode('partial image'));
+            },
+            pull(controller) {
+                closeTimer ||= setTimeout(() => controller.close(), 100);
+            },
+            cancel() {
+                clearTimeout(closeTimer);
+                bodyCancelled = true;
+            },
+        });
+        globalThis.fetch = async () => new Response(upstreamBody, {
+            headers: { 'content-type': 'image/jpeg' },
+        });
+
+        let firstWrite;
+        const firstWritePromise = new Promise((resolve) => { firstWrite = resolve; });
+        const res = new Writable({
+            write(_chunk, _encoding, callback) {
+                firstWrite();
+                callback();
+            },
+        });
+        res.locals = {};
+        res.setHeader = () => res;
+        res.status = (code) => { res.statusCode = code; return res; };
+        res.json = (payload) => { res.body = payload; return res; };
+
+        const handlerPromise = googleMapHandler(createRequest({
+            query: { latitude: '1', longitude: '2', language: 'en' },
+        }), res);
+        await firstWritePromise;
+        res.destroy();
+        await handlerPromise;
+
+        assert.equal(bodyCancelled, true);
     });
 });
 

--- a/tests/api-handlers.test.js
+++ b/tests/api-handlers.test.js
@@ -193,6 +193,52 @@ describe('google-map handler', () => {
         assert.deepEqual(res.body, { error: 'upstream reset' });
     });
 
+    it('cancels the upstream body when the client disconnects before the first chunk', async () => {
+        let closeBody;
+        let bodyCancelled = false;
+        const upstreamBody = new ReadableStream({
+            start(controller) {
+                closeBody = () => controller.close();
+            },
+            cancel() {
+                bodyCancelled = true;
+            },
+        });
+        globalThis.fetch = async () => new Response(upstreamBody, {
+            headers: { 'content-type': 'image/jpeg' },
+        });
+
+        const res = new Writable({
+            write(_chunk, _encoding, callback) {
+                callback();
+            },
+        });
+        res.locals = {};
+        res.setHeader = () => res;
+        res.status = (code) => { res.statusCode = code; return res; };
+        res.json = (payload) => { res.body = payload; return res; };
+
+        const handlerPromise = googleMapHandler(createRequest({
+            query: { latitude: '1', longitude: '2', language: 'en' },
+        }), res);
+        await new Promise(setImmediate);
+        res.destroy();
+
+        let timeoutId;
+        const settledPromptly = await Promise.race([
+            handlerPromise.then(() => true),
+            new Promise((resolve) => { timeoutId = setTimeout(() => resolve(false), 100); }),
+        ]);
+        clearTimeout(timeoutId);
+        if (!settledPromptly) {
+            closeBody();
+            await handlerPromise;
+        }
+
+        assert.equal(settledPromptly, true);
+        assert.equal(bodyCancelled, true);
+    });
+
     it('closes a partial image response when the upstream stream fails', async () => {
         const upstreamBody = new ReadableStream({
             start(controller) {


### PR DESCRIPTION
## Summary

- Read the first map body chunk before starting the client response.
- Return a 500 JSON response when that first read fails.
- Cancel the first read when the client disconnects.
- Stream later chunks through `pipeline()`.
- Close partial responses after streaming starts.
- Cancel the remaining upstream body when the client disconnects.

## Root cause

The original handler did not observe stream errors. The first fix passed `res` directly to `pipeline()`.

`pipeline()` destroys its destination before rejecting. That prevented a 500 response when the body failed before its first chunk.

The first read also occurred before `pipeline()` started. A client disconnect could leave that read pending.

## Impact

Early upstream failures now return 500 JSON. Later failures close the partial response.

Client disconnects cancel the upstream body before or after the first chunk.

## Validation

- `pnpm check`
- Regression tests cover completion, early reset, partial reset, and both disconnect stages.
- The production build passed.

Closes #363