### PR TITLE
Fix(deps): pin @grpc/grpc-js to patched 1.9.16 (CVE-2026-48068, defense-in-depth)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,10 @@
     "tailwindcss": "^4.3.3",
     "vconsole": "^3.15.1",
     "vite": "^8.2.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@grpc/grpc-js": "1.9.16"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,10 +73,5 @@
     "tailwindcss": "^4.3.3",
     "vconsole": "^3.15.1",
     "vite": "^8.2.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "@grpc/grpc-js": "1.9.16"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@grpc/grpc-js': 1.9.16
+
 importers:
 
   .:
@@ -559,8 +562,8 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
-  '@grpc/grpc-js@1.9.15':
-    resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
     engines: {node: ^8.13.0 || >=10.10.0}
 
   '@grpc/proto-loader@0.7.15':
@@ -3212,7 +3215,7 @@ snapshots:
       '@firebase/logger': 0.5.2
       '@firebase/util': 1.15.3
       '@firebase/webchannel-wrapper': 1.0.7
-      '@grpc/grpc-js': 1.9.15
+      '@grpc/grpc-js': 1.9.16
       '@grpc/proto-loader': 0.7.15
       re2js: 2.8.6
       tslib: 2.8.1
@@ -3383,7 +3386,7 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@grpc/grpc-js@1.9.15':
+  '@grpc/grpc-js@1.9.16':
     dependencies:
       '@grpc/proto-loader': 0.7.15
       '@types/node': 24.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Force the patched @grpc/grpc-js (CVE-2026-48068). It arrives only as a
+# transitive dep of @firebase/firestore, which this app never imports
+# (only firebase/app + firebase/auth) — kept as defense-in-depth. 1.9.16 stays
+# within firestore's declared ~1.9.0 range, so it's an in-range patch bump.
+overrides:
+  '@grpc/grpc-js': 1.9.16
 allowBuilds:
   '@code-inspector/core': true
   '@firebase/util': true


### PR DESCRIPTION
## Summary

Trivy flagged a vulnerable transitive `@grpc/grpc-js` (CVE-2026-48068). This PR forces the resolved version to the patched **`1.9.16`** via a pnpm override and regenerates `pnpm-lock.yaml` so `--frozen-lockfile` installs stay consistent in CI.

## Reachability (honest scope)

The vulnerable **server-side gRPC** path is **not** reachable in MyIP:

- `pnpm why @grpc/grpc-js` shows it enters **only** via `@firebase/firestore` → `@firebase/firestore-compat` → `firebase`.
- The app imports only `firebase/app` and `firebase/auth` — **never** `firebase/firestore`.
- MyIP runs **no gRPC server**, and this is a browser-side Firebase Auth dependency.

So this is **dependency-level remediation / defense-in-depth**, not a demonstrated remotely exploitable issue.

## Implementation notes

- The override lives in **`pnpm-workspace.yaml`** (`overrides:`), not the `pnpm` field in `package.json` — pnpm 11 no longer reads that field, so the original commit's override was silently ignored and never applied.
- `pnpm-lock.yaml` is regenerated: `@grpc/grpc-js` `1.9.15` → `1.9.16`.
- `1.9.16` stays within firestore's declared `~1.9.0` range, so it's an in-range patch bump (lower risk than forcing a cross-minor version onto a package that's never loaded).

## Verification

- `pnpm why @grpc/grpc-js` → `1.9.16`, no warning about an ignored field.
- `pnpm install --frozen-lockfile` → passes (this is what CI runs).
- `pnpm check` (test + build) → 907 tests pass, build succeeds.
