### PR TITLE
docs: fix stale locale comment

### DIFF
--- a/frontend/data/default-preferences.js
+++ b/frontend/data/default-preferences.js
@@ -26,7 +26,7 @@ export const DEFAULT_PREFERENCES = Object.freeze({
   // Local IP-history recorder (see use-ip-history.js). Days: 1–90.
   ipHistoryEnabled: true,
   ipHistoryDays: 90,
-  lang: 'auto', // auto | zh | en | fr | tr
+  lang: 'auto', // auto | zh | en | fr | ru
   // The full Connectivity target set (defaults included). null until first
   // load — store.loadPreferences() runs it through sanitizeTargets(), which
   // also rebuilds a hand-emptied or corrupted stored value.


### PR DESCRIPTION
## Summary
- update the locale comment in `frontend/data/default-preferences.js` from Turkish (`tr`) to Russian (`ru`)

## Why
The application ships `en`, `zh`, `fr`, and `ru`; the comment still listed the removed Turkish locale.

## Impact
This is a documentation-only correction to the default preferences source comment. Runtime behavior is unchanged.

## Verification
- `git diff --check` ✅
- `pnpm check` not run: dependencies are not installed in the clean workbench checkout.

Closes #407

This change was prepared with AI assistance.