### PR TITLE
Fix(ui): keep the connectivity status label inside its card

### DIFF
--- a/frontend/components/ConnectivityTest.vue
+++ b/frontend/components/ConnectivityTest.vue
@@ -51,20 +51,20 @@
             <span class="text-base font-medium truncate">{{ test.name }}</span>
           </div>
           <!-- Status + ms. Multi mode pins these to the best round (see checkConnectivityHandler). -->
-          <div class="flex items-center justify-between gap-2">
-            <span class="flex items-center gap-1.5 text-base min-w-0">
+          <div class="flex items-center justify-between gap-2 text-sm md:text-base">
+            <span class="flex items-center gap-1.5 min-w-0">
               <span v-if="toneOf(test) === 'wait'" class="relative flex shrink-0">
                 <span class="absolute inline-flex size-2 rounded-full bg-info opacity-75 animate-ping"></span>
                 <span class="relative inline-flex size-2 rounded-full" :class="dotClass(toneOf(test))"></span>
               </span>
               <component v-else-if="statusFaceIcon(test)" :is="statusFaceIcon(test)" class="size-4 shrink-0"
                 :class="textClass(toneOf(test))" />
-              <span :class="textClass(toneOf(test))" class="font-mono whitespace-nowrap min-w-0">{{ test.status
+              <span :class="textClass(toneOf(test))" class="min-w-0 truncate" :title="test.status">{{ test.status
                 }}</span>
             </span>
-            <span v-if="test.time !== 0" class="text-base font-mono tabular-nums text-muted-foreground"
+            <span v-if="test.time !== 0" class="shrink-0 font-mono tabular-nums text-muted-foreground"
               :title="t('connectivity.minTestTime') + test.mintime + ' ms'">
-              {{ test.time }}<span class="ml-0.5 text-sm">ms</span>
+              {{ test.time }}<span class="ml-0.5 text-xs md:text-sm">ms</span>
             </span>
           </div>
           <!-- Multi-test per-round latency bars, all on one absolute scale


### PR DESCRIPTION
Closes #429.

## Problem

On a phone the connectivity cards sit two per row. With auto-test off every card shows the `connectivity.StatusWait` label, and in the longer locales it spills out of the card — `en` is 13 characters, `pt-BR` 16, `fr` 18.

The span in `frontend/components/ConnectivityTest.vue` carried `font-mono whitespace-nowrap min-w-0`: wrapping was forbidden and nothing clipped, so the text simply pushed past the card edge. Monospace also cost ~20% extra width for what is prose — only the `ms` number needs tabular digits.

## Change

Four class edits, all in the status row of `ConnectivityTest.vue`:

- The row drops one size on phones only (`text-sm md:text-base`); `md` and up is untouched.
- The status label loses `font-mono` and gains `truncate`, so it always fits and degrades to an ellipsis instead of escaping the card. `:title="test.status"` keeps the full string reachable.
- `shrink-0` on the latency value makes the label give way first, never the number.
- The `ms` suffix follows the row down a step (`text-xs md:text-sm`).

The label stays on a **single** line: letting it wrap would mean two lines while waiting and one once the result reads `OK`, so every card would change height when a run finishes and the page would jump on a section refresh.

No locale files touched.

## Validation

- `pnpm build` — green.
- `pnpm test` — 1093 pass / 3 fail; the same three (`localProfile`, `formatDuration`) fail on an unmodified `dev` checkout, so they are pre-existing and unrelated to this change.
- This is a CSS-only change to a Tailwind class list; I could not exercise the 375px pt-BR/fr rendering headlessly, so the visual acceptance criteria are worth a quick look on your side.