### PR TITLE
fix(nav): prevent truncation of long tool names in mobile drawer and desktop dropdown (#430)

### DIFF
--- a/frontend/components/Nav.vue
+++ b/frontend/components/Nav.vue
@@ -45,12 +45,12 @@
                 </NavigationMenuTrigger>
                 <NavigationMenuContent class="z-50">
                   <!-- Two-column grid on PC -->
-                  <ul class="relative grid grid-cols-2 gap-x-4 gap-y-0.5 min-w-[24rem]">
+                  <ul class="relative grid grid-cols-2 gap-x-4 gap-y-0.5 min-w-[28rem]">
                     <span aria-hidden="true"
                       class="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-border"></span>
                     <li v-for="tool in advancedTools" :key="tool.slug">
                       <NavigationMenuLink as-child class="cursor-pointer">
-                        <button type="button" class="w-full truncate text-left" @click="openTool(tool.slug)">
+                        <button type="button" class="w-full text-left leading-snug" @click="openTool(tool.slug)">
                           {{ t(tool.titleKey) }}
                         </button>
                       </NavigationMenuLink>
@@ -203,7 +203,7 @@
     <!-- Mobile navigation drawer. Flex column so the link list scrolls instead
          of clipping on short screens when Advanced Tools is expanded. -->
     <Sheet v-if="isMobile" :open="isNavMenuOpen" @update:open="onNavMenuChange">
-      <SheetContent side="left" class="w-72 p-0 flex flex-col gap-0" :title="t('nav.Navigation')">
+      <SheetContent side="left" class="w-80 p-0 flex flex-col gap-0" :title="t('nav.Navigation')">
         <div class="flex shrink-0 items-center justify-between border-b px-4 py-3">
           <h5 class="m-0 text-base font-semibold">{{ t('nav.Navigation') }}</h5>
           <SheetClose />
@@ -224,7 +224,7 @@
               <CollapsibleContent>
                 <div class="my-0.5 ml-3 flex flex-col gap-0.5 border-l pl-3">
                   <button v-for="tool in advancedTools" :key="tool.slug" type="button"
-                    class="block w-full truncate rounded-md px-3 py-1.5 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                    class="block w-full rounded-md px-3 py-1.5 text-left text-sm leading-snug text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
                     @click="openTool(tool.slug)">
                     {{ t(tool.titleKey) }}
                   </button>


### PR DESCRIPTION
> ⚠️ **Open this PR against the `dev` branch, not `main`.** `main` only receives release merges from `dev`.

## What & why

Widens the mobile navigation drawer from `w-72` to `w-80` and the desktop dropdown grid from `min-w-[24rem]` to `min-w-[28rem]`, and replaces `truncate` with `leading-snug` on tool item buttons in `frontend/components/Nav.vue`.

This prevents long translated tool names (such as `enhanceddnsleaktest.Title`, `personacheck.Title`, and `securitychecklist.Title` in Portuguese, French, and Russian) from being clipped with an ellipsis in both the mobile drawer and desktop navigation dropdown, allowing every tool name to render in full and wrap cleanly if needed.

Closes #430

## Checklist

- [x] Targets `dev`; one concern per PR
- [x] `pnpm check` is green locally (tests + build)
- [ ] Logic changes ship with a spec in `tests/`
- [ ] User-visible copy lands in all four locales (`en` / `zh` / `fr` / `ru`)
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the relevant `AGENTS.md`
