### PR TITLE
docs: require Node.js 24 for contributor setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ New here? Look for issues labeled
 
 1. **Fork** the repo and create your branch **from `dev`** (never `main` — `main` only
    receives release merges from `dev`).
-2. **Set up:** Node.js 20+ (CI runs on Node 24) and pnpm. The pnpm version is pinned
+2. **Set up:** Node.js 24+ (same as CI) and pnpm. The pnpm version is pinned
    via the `packageManager` field, so the easiest path is:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "7.4.0",
   "type": "module",
   "packageManager": "pnpm@11.22.0",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "concurrently \"vite\" \"nodemon --import ./sentry-instrument.js backend-server.js\"",
     "build": "vite build",


### PR DESCRIPTION
## What & why

- require Node.js 24+ in the contributor setup instructions, matching CI and the `Intl` APIs used by the test suite
- declare `engines.node` in `package.json` so the requirement is machine-readable

Closes #434.

## Testing

- Node.js v24.10.0
- `pnpm install --frozen-lockfile` (completed without changing `pnpm-lock.yaml`)
- `pnpm check` (1,096 tests passed and the production build completed)

## Checklist

- [x] Targets `dev`; one concern per PR
- [x] `pnpm check` is green locally (tests + build)
- [x] Logic changes ship with a spec in `tests/` (N/A — no application logic changed)
- [x] User-visible copy lands in all four locales (`en` / `zh` / `fr` / `ru`) (N/A — contributor setup only)
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the relevant `AGENTS.md`

## AI assistance

AI assistance was used to validate the issue scope, apply the two-file change, and run the documented checks. I reviewed the final diff and verification results.

