### PR TITLE
Chore: require Node 24 in contributing docs and engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ New here? Look for issues labeled
 
 1. **Fork** the repo and create your branch **from `dev`** (never `main` — `main` only
    receives release merges from `dev`).
-2. **Set up:** Node.js 20+ (CI runs on Node 24) and pnpm. The pnpm version is pinned
+2. **Set up:** Node.js 24+ (same as CI; the test suite uses `Intl` APIs that landed in Node 23) and pnpm. The pnpm version is pinned
    via the `packageManager` field, so the easiest path is:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "7.4.0",
   "type": "module",
   "packageManager": "pnpm@11.22.0",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "concurrently \"vite\" \"nodemon --import ./sentry-instrument.js backend-server.js\"",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Closes #434.

The test suite uses `Intl.Locale#getTimeZones()` and `Intl.DurationFormat`, both of which landed in Node 23, so a contributor following the current `Node.js 20+` instruction gets three unrelated failures.

This makes the requirement accurate in two places:

- `CONTRIBUTING.md`: `Node.js 20+ (CI runs on Node 24)` → `Node.js 24+ (same as CI; the test suite uses `Intl` APIs that landed in Node 23)`
- `package.json`: add `"engines": { "node": ">=24" }` next to `packageManager`

## Verification

- `package.json` parses as valid JSON.
- `pnpm-lock.yaml` is unchanged.
- I could not complete a full `pnpm check` locally because npm registry fetches for a few packages (firebase, sentry, lightningcss, etc.) timed out in this environment; the change is docs + metadata only and does not touch code or tests.

Prepared with OpenAI Codex (GPT-5) assistance.