### PR TITLE
Feat(dns): add CZ.NIC ODVR (Czechia) resolver

### DIFF
--- a/api/data/dns-resolvers.js
+++ b/api/data/dns-resolvers.js
@@ -42,4 +42,5 @@ export const DNS_RESOLVERS = [
     { id: 'dnspod', name: 'DNSPod', country: 'CN', udp: '119.29.29.29' },
     { id: '114dns', name: '114DNS', country: 'CN', udp: '114.114.114.114' },
     { id: 'dns4eu', name: 'DNS4EU', country: 'EU', udp: '86.54.11.1' },
+    { id: 'cznic', name: 'CZ.NIC ODVR', country: 'CZ', udp: '193.17.47.1' },
 ];


### PR DESCRIPTION
Fixes #392 (rescoped to "Add a reachable public resolver from Europe").

Adds CZ.NIC ODVR, the public validating resolver run by the `.cz` registry, improving European coverage.

- `id: 'cznic'`, `name: 'CZ.NIC ODVR'`, `country: 'CZ'`
- `udp: '193.17.47.1'` — PTR `odvr.nic.cz`, DNSSEC-validating, verified reachable with `ra` set and honest NXDOMAIN
- UDP-only: its DoH endpoint does not serve the `application/dns-json` API this endpoint queries

Verification:
- `node --test tests/dns-resolvers-data.test.js`: 7 passed
- `dig @193.17.47.1 example.com` returns `NOERROR` with the `ra` flag set

Prepared with OpenAI Codex assistance.