### PR TITLE
Feat(dns): add Yandex.DNS (Russia) resolver

### DIFF
--- a/api/data/dns-resolvers.js
+++ b/api/data/dns-resolvers.js
@@ -38,6 +38,7 @@ export const DNS_RESOLVERS = [
     { id: 'quad9', name: 'Quad9', country: 'CH', udp: '9.9.9.9' },
     { id: 'controld', name: 'ControlD', country: 'CA', udp: '76.76.2.0' },
     { id: 'adguard', name: 'AdGuard', country: 'CY', udp: '94.140.14.14', doh: 'https://dns.adguard.com/resolve?' },
+    { id: 'yandex', name: 'Yandex.DNS', country: 'RU', udp: '77.88.8.8' },
     { id: 'alidns', name: 'AliDNS', country: 'CN', udp: '223.5.5.5', doh: 'https://dns.alidns.com/resolve?' },
     { id: 'dnspod', name: 'DNSPod', country: 'CN', udp: '119.29.29.29' },
     { id: '114dns', name: '114DNS', country: 'CN', udp: '114.114.114.114' },


### PR DESCRIPTION
Fixes #390.

Adds Yandex.DNS, the public resolver run by Yandex, to fill the missing `RU` entry.

- `id: 'yandex'`, `name: 'Yandex.DNS'`, `country: 'RU'`
- `udp: '77.88.8.8'` — Yandex's public unfiltered resolver (secondary `77.88.8.1` intentionally omitted: the list is per service, not per IP)
- UDP-only: Yandex's DoH endpoint speaks RFC 8484 wire format (`application/dns-message`), not the `application/dns-json` API this endpoint queries

Verification (run from outside Russia):
```console
$ dig +time=3 +tries=1 @77.88.8.8 example.com A
;; flags: qr rd ra;  status: NOERROR,  ANSWER: 2

$ dig @77.88.8.8 this-domain-does-not-exist-8f3a.example A
;; status: NXDOMAIN
```

- `node --test tests/dns-resolvers-data.test.js`: 7 passed

Prepared with OpenAI Codex assistance.