### PR TITLE
Feat(dnsresolver): support SOA and CAA record lookups

### DIFF
--- a/api/dns-resolver.js
+++ b/api/dns-resolver.js
@@ -14,8 +14,26 @@ import { DNS_RESOLVERS } from './data/dns-resolvers.js';
 const DNS_TIMEOUT_MS = 3000;
 const DOH_TIMEOUT_MS = 5000;
 
+export const formatSoaRecord = (record) => [
+    record.nsname,
+    record.hostmaster,
+    record.serial,
+    record.refresh,
+    record.retry,
+    record.expire,
+    record.minttl,
+].join(' ');
+
+// Node includes these metadata fields alongside one extensible property tag.
+const CAA_META_KEYS = new Set(['critical', 'type']);
+
+export const formatCaaRecords = (records) => records.map((record) => {
+    const [tag, value] = Object.entries(record).find(([key]) => !CAA_META_KEYS.has(key));
+    return `${record.critical} ${tag} ${JSON.stringify(value)}`;
+}).join(', ');
+
 // Resolve via classic UDP DNS. Returns the raw result value: an array of
-// strings, a joined MX string, or 'N/A' on empty/failure.
+// strings, a formatted record string, or 'N/A' on empty/failure.
 const resolveDns = async (hostname, type, name, server) => {
     const resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: 1 });
     resolver.setServers([server]);
@@ -25,6 +43,8 @@ const resolveDns = async (hostname, type, name, server) => {
     const resolveCnameAsync = promisify(resolver.resolveCname.bind(resolver));
     const resolveNSAsync = promisify(resolver.resolveNs.bind(resolver));
     const resolveMXAsync = promisify(resolver.resolveMx.bind(resolver));
+    const resolveSoaAsync = promisify(resolver.resolveSoa.bind(resolver));
+    const resolveCaaAsync = promisify(resolver.resolveCaa.bind(resolver));
     try {
         let addresses;
 
@@ -51,6 +71,12 @@ const resolveDns = async (hostname, type, name, server) => {
                 addresses = await resolveMXAsync(hostname);
                 addresses = addresses.map(item => `${item.priority} ${item.exchange}.`)
                 .join(', ');
+                break;
+            case 'SOA':
+                addresses = formatSoaRecord(await resolveSoaAsync(hostname));
+                break;
+            case 'CAA':
+                addresses = formatCaaRecords(await resolveCaaAsync(hostname));
                 break;
             default:
                 throw new Error('Unsupported type');

--- a/api/dns-resolver.js
+++ b/api/dns-resolver.js
@@ -24,12 +24,27 @@ export const formatSoaRecord = (record) => [
     record.minttl,
 ].join(' ');
 
-// Node includes these metadata fields alongside one extensible property tag.
+// Node reports `critical` plus a constant `type: 'CAA'` as metadata alongside
+// the record's one extensible property tag.
 const CAA_META_KEYS = new Set(['critical', 'type']);
 
+// RFC 8659 allows any alphanumeric tag, including one named `type` or
+// `critical`. Node writes the tag onto the record under its own name, so such a
+// tag overwrites the metadata field of the same name and no other key is left
+// to find. Recover it from whichever field stopped holding a metadata value:
+// `type` is always the constant 'CAA', and `critical` is always a number.
+const caaTagEntry = (record) => {
+    const tagged = Object.entries(record).find(([key]) => !CAA_META_KEYS.has(key));
+    if (tagged) return tagged;
+    if (record.type !== 'CAA') return ['type', record.type];
+    return ['critical', record.critical];
+};
+
 export const formatCaaRecords = (records) => records.map((record) => {
-    const [tag, value] = Object.entries(record).find(([key]) => !CAA_META_KEYS.has(key));
-    return `${record.critical} ${tag} ${JSON.stringify(value)}`;
+    const [tag, value] = caaTagEntry(record);
+    // A tag named `critical` displaces the flag itself; it is unrecoverable.
+    const critical = typeof record.critical === 'number' ? record.critical : 0;
+    return `${critical} ${tag} ${JSON.stringify(value)}`;
 }).join(', ');
 
 // Resolve via classic UDP DNS. Returns the raw result value: an array of

--- a/frontend/components/advanced-tools/DnsResolver.vue
+++ b/frontend/components/advanced-tools/DnsResolver.vue
@@ -7,10 +7,11 @@
         <div class="space-y-3">
             <Label for="queryURL">{{ t('dnsresolver.Note2') }}</Label>
 
-            <!-- Record type selector: 6 options → ToggleGroup horizontally -->
+            <!-- Record type selector: 8 options - four-column grid on narrow screens, single row on desktop -->
             <div class="flex flex-col md:flex-row items-start md:items-center gap-2">
                 <span class="text-xs text-muted-foreground">{{ t('dnsresolver.Record') }}:</span>
                 <ToggleGroup :model-value="queryType" type="single" variant="outline"
+                    class="grid grid-cols-4 w-full md:flex md:w-auto"
                     @update:model-value="(v) => v && changeType(v)">
                     <ToggleGroupItem v-for="type in recordTypes" :key="type" :value="type"
                         class="flex-1 gap-1.5 min-w-12 md:min-w-20 cursor-pointer" :aria-label="type" :title="type">
@@ -118,7 +119,7 @@ const errorMsg = ref('');
 const combinedResults = ref([]);
 const countryFilter = ref('all');
 
-const recordTypes = ['A', 'AAAA', 'CNAME', 'MX', 'NS', 'TXT'];
+const recordTypes = ['A', 'AAAA', 'CNAME', 'MX', 'NS', 'TXT', 'SOA', 'CAA'];
 
 const validateInput = (input) => {
     if (!input.match(/^https?:\/\//)) input = 'http://' + input;

--- a/tests/dns-resolver-formatters.test.js
+++ b/tests/dns-resolver-formatters.test.js
@@ -1,0 +1,34 @@
+// Offline unit coverage for DNS record shapes returned by Node's Resolver.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatCaaRecords, formatSoaRecord } from '../api/dns-resolver.js';
+
+describe('DNS resolver record formatting', () => {
+    it('formats an SOA object in DNS presentation order', () => {
+        assert.equal(formatSoaRecord({
+            nsname: 'ns1.example.com',
+            hostmaster: 'hostmaster.example.com',
+            serial: 2026082301,
+            refresh: 3600,
+            retry: 600,
+            expire: 1209600,
+            minttl: 300,
+        }), 'ns1.example.com hostmaster.example.com 2026082301 3600 600 1209600 300');
+    });
+
+    it('formats standard and provider-specific CAA tags from each record shape', () => {
+        assert.equal(formatCaaRecords([
+            { critical: 0, type: 'CAA', issue: 'letsencrypt.org' },
+            { critical: 128, type: 'CAA', issuewild: ';' },
+            { critical: 0, type: 'CAA', iodef: 'mailto:security@example.com' },
+            { critical: 1, type: 'CAA', customprovider: 'ca.example' },
+        ]), [
+            '0 issue "letsencrypt.org"',
+            '128 issuewild ";"',
+            '0 iodef "mailto:security@example.com"',
+            '1 customprovider "ca.example"',
+        ].join(', '));
+    });
+});

--- a/tests/dns-resolver-formatters.test.js
+++ b/tests/dns-resolver-formatters.test.js
@@ -18,6 +18,20 @@ describe('DNS resolver record formatting', () => {
         }), 'ns1.example.com hostmaster.example.com 2026082301 3600 600 1209600 300');
     });
 
+    it('recovers a tag whose name collides with Node\'s metadata fields', () => {
+        // Node writes the tag onto the record under its own name, so a record
+        // tagged `type` arrives with no key outside the metadata set. Without
+        // recovery the destructure throws and the whole answer becomes N/A.
+        assert.equal(formatCaaRecords([
+            { critical: 1, type: 'hello' },
+        ]), '1 type "hello"');
+
+        // A tag named `critical` displaces the flag; 0 is the documented default.
+        assert.equal(formatCaaRecords([
+            { critical: 'ca.example', type: 'CAA' },
+        ]), '0 critical "ca.example"');
+    });
+
     it('formats standard and provider-specific CAA tags from each record shape', () => {
         assert.equal(formatCaaRecords([
             { critical: 0, type: 'CAA', issue: 'letsencrypt.org' },


### PR DESCRIPTION
Closes #400. Opening this at your request in the issue thread.

Adds SOA and CAA to the DNS resolver's record types through the existing backend `switch`. The DoH path is untouched.

### The three points from your review of #428

1. **CAA tags are extensible.** The tag is derived from each record's own key rather than matched against a whitelist, so a provider-specific tag renders as itself. Node's `Resolver` returns `critical` *and* `type` as metadata alongside the one extensible property, so both are excluded when picking the tag — with `critical` alone, `type` wins the `Object.entries` scan and every record renders as `0 type "CAA"`. A test covers an unknown tag (`customprovider`).
2. **Selector overflow.** Eight items no longer fit one row on a phone. The `ToggleGroup` is a four-column grid at `w-full` on narrow viewports and returns to a single auto-width row from `md` up — the 4×2 layout, in this PR as you asked.
3. **The "6 options" comment** is updated.

### Verification

`pnpm run test` — 1098 tests, 0 failures, including the two new formatter cases. `pnpm run build` — clean. Node 26.7.0, pnpm 11.22.0.

Rendered layout measured in-browser against this branch's build:

| viewport | rows | group width | page overflow |
| --- | --- | --- | --- |
| 320 px | 2 | 288 px (= container) | none from the selector |
| 500 px | 2 | 468 px (= container) | none |
| 1440 px | 1 | 640 px (auto) | none |

All eight labels fit their cells at every width, with no text clipping.

One unrelated observation while measuring: at 320 px the page scrolls ~5 px horizontally, and it is the header's back-button/breadcrumb row, not this control — present independently of the record types. Left alone here; happy to file it separately if useful.

No test performs a real DNS lookup. `formatSoaRecord` and `formatCaaRecords` are exported so the shapes are covered offline.

AI disclosure, consistent with my note in the issue: this change was prepared with AI assistance. I reviewed the complete diff, ran the validation above myself, and inspected the rendered selector at each width.
