### PR TITLE
fix(header): keep the standalone header inside a 320px viewport

### DIFF
--- a/frontend/components/StandalonePageHeader.vue
+++ b/frontend/components/StandalonePageHeader.vue
@@ -24,10 +24,17 @@
         <span class="min-w-0 truncate font-medium">{{ title }}</span>
       </template>
       <!-- Button `as-child` renders the RouterLink as its root, so this is a
-           single <a> styled as a button — not a <button> nested in an <a>. -->
-      <Button as-child variant="default" class="ml-auto shrink-0 cursor-pointer">
+           single <a> styled as a button — not a <button> nested in an <a>.
+           Icon-only below `sm`: brand (132px) + this button's label (up to
+           178px in pt-BR) + gaps + px-4 exceeded 320px, and since the title is
+           the only item that can shrink, it collapsed to 0 and the row still
+           overflowed — a dangling "/" plus a clipped button. `sr-only` (not
+           `hidden`) keeps the accessible name in every locale, and being out of
+           flow it costs no `gap-2`. -->
+      <Button as-child variant="default" size="icon" class="ml-auto shrink-0 cursor-pointer sm:w-auto sm:px-4">
         <RouterLink to="/">
-          <ArrowLeft class="size-4" /> {{ t('advancedtools.BackToHome') }}
+          <ArrowLeft class="size-4" />
+          <span class="sr-only sm:not-sr-only">{{ t('advancedtools.BackToHome') }}</span>
         </RouterLink>
       </Button>
     </div>


### PR DESCRIPTION
Closes #445.

The standalone header row (`/tools/:slug`, `/privacy`, `/r/:id`) is a flex line where the breadcrumb title is the only item that can shrink. Once it collapses to 0 the row still needs `32 (px-4) + 132.3 (brand) + 8 + 4.6 (/) + 8 + 0 + 8 + 148.2 (button) = 341.1 px`, so a 320 px viewport scrolls sideways and the button clips mid-word — worse in the longer locales.

Making the back button icon-only below `sm` frees ~112 px. `sr-only` rather than `hidden` keeps the accessible name in every locale at every width, and being out of flow it costs no `gap-2`.

### Measured

`dev` @ `0a0a739`, Chrome 151, mobile emulation at DPR 2, `documentElement.scrollWidth - clientWidth` and the breadcrumb span's `getBoundingClientRect().width`:

| locale | back-button label | overflow @320 | breadcrumb width @320 | button @320 | button @640 |
| --- | --- | --- | --- | --- | --- |
| `en` | Back to Home | 5 → **0** | 0 → **91.2 px** | 36 px | 148.2 px |
| `fr` | Retour à l'accueil | 26 → **0** | 0 → **91.2 px** | 36 px | 169.6 px |
| `pt-BR` | Voltar para o início | 35 → **0** | 0 → **91.2 px** | 36 px | 178.5 px |
| `ru` | На главную | 0 → 0 | 0 → **91.2 px** | 36 px | 135.5 px |
| `zh` | 回到首页 | 0 → 0 | 15.2 → **89.3 px** (its full text) | 36 px | 112.0 px |

So the breadcrumb renders text at 320 px for the first time rather than being merely un-clipped, and the ≥640 px layout is unchanged — I measured `639` and `640` either side of the breakpoint and only the button changes.

`/privacy` carried the identical 5 px in `en` and is fixed by the same change; `Nav.vue` on the homepage was never affected.

Inspected the rendered header myself at 320 px in `en` and `pt-BR` and at 700 px in `en`.

### Validation

`pnpm check` on Node 26.7.0 / pnpm 11.22.0: production build clean, 1138/1139 tests pass.

The one failure is `tests/composable-globalping-measurement.test.js:88` — "retries while in-progress, then finishes when the last poll returns success" — and it is a pre-existing flake, not this change. It asserts after a fixed `setTimeout(80)` that has to cover a POST plus three `pollInterval: 5` polls, so it loses under load. I ran it 15 times with this patch and 15 times without, interleaved on the same machine: **1 failure in 15 either way**. A full-suite run before this commit hit it too. Its failure mode is `status === 'running'` where `'finished'` is expected — a wait that expired, not a wrong result.

Nothing in this diff is reachable from that test; it is a template-only change to one header component. I'll open a separate PR to harden that wait, since it's its own concern.

### Design note

The tradeoff is that phones get the arrow without the words. The other lever is the brand — dropping the `IPCheck.ing` wordmark below `sm` frees a comparable ~105 px and would keep the label. I picked the button because it leaves the brand, which is also the home link, fully legible. Happy to switch if you'd rather keep the words.

AI disclosure, consistent with #442 and #445: prepared with AI assistance. I reviewed the complete diff, ran every measurement above, and inspected the rendered header at each width myself.
