### PR TITLE
test(globalping): wait on conditions instead of fixed delays

### DIFF
--- a/tests/composable-globalping-measurement.test.js
+++ b/tests/composable-globalping-measurement.test.js
@@ -47,19 +47,17 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 //
 // A fixed sleep cannot do this job: a run here spans a POST plus up to three
 // real `pollInterval` timers, so any constant is either flaky when the machine
-// is loaded or slow on every green run. The "retries while in-progress" case
-// used to allow 80ms for that chain and failed under a parallel suite with
-// status still 'running' — a wait that expired, reported as a wrong result.
+// is loaded or slow on every green run.
 //
 // The timeout only bounds a hang; it is never reached on a passing run.
-async function waitFor(predicate, { timeout = 2000, label = 'condition' } = {}) {
+const waitFor = async (predicate, { timeout = 2000, label = 'condition' } = {}) => {
   const deadline = Date.now() + timeout;
   for (;;) {
     if (predicate()) return;
     if (Date.now() > deadline) throw new Error(`timed out after ${timeout}ms waiting for ${label}`);
     await tick();
   }
-}
+};
 
 describe('useGlobalpingMeasurement()', () => {
   beforeEach(() => {

--- a/tests/composable-globalping-measurement.test.js
+++ b/tests/composable-globalping-measurement.test.js
@@ -42,6 +42,25 @@ function withScope(fn) {
 // promises settle before we assert.
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
+// Wait until `predicate()` holds, polling on a macrotask so the composable's
+// setTimeout-driven poll chain can advance between checks.
+//
+// A fixed sleep cannot do this job: a run here spans a POST plus up to three
+// real `pollInterval` timers, so any constant is either flaky when the machine
+// is loaded or slow on every green run. The "retries while in-progress" case
+// used to allow 80ms for that chain and failed under a parallel suite with
+// status still 'running' — a wait that expired, reported as a wrong result.
+//
+// The timeout only bounds a hang; it is never reached on a passing run.
+async function waitFor(predicate, { timeout = 2000, label = 'condition' } = {}) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline) throw new Error(`timed out after ${timeout}ms waiting for ${label}`);
+    await tick();
+  }
+}
+
 describe('useGlobalpingMeasurement()', () => {
   beforeEach(() => {
     globalThis.fetch = originalFetch;
@@ -73,8 +92,7 @@ describe('useGlobalpingMeasurement()', () => {
         onError: () => { errorCalls++; },
       });
 
-      // wait for the poll to land (initial create + one setTimeout(pollInterval))
-      await tick(); await tick(); await new Promise((r) => setTimeout(r, 20));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
 
       assert.equal(value.status.value, 'finished');
       assert.equal(finishCalls, 1);
@@ -105,7 +123,7 @@ describe('useGlobalpingMeasurement()', () => {
       value.start({}, {
         onResults: (d) => d.results.length > 0,
       });
-      await new Promise((r) => setTimeout(r, 80));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
       assert.equal(value.status.value, 'finished');
       assert.equal(pollCount, 3);
     } finally {
@@ -131,7 +149,7 @@ describe('useGlobalpingMeasurement()', () => {
         onResults: () => false,
         onError: (r) => errorReasons.push(r),
       });
-      await new Promise((r) => setTimeout(r, 60));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
       assert.equal(value.status.value, 'error');
       assert.deepEqual(errorReasons, ['empty']);
       // 1 initial poll + 2 retries = 3 total
@@ -160,7 +178,7 @@ describe('useGlobalpingMeasurement()', () => {
     );
     try {
       value.start({}, { onError: (r) => errorReasons.push(r) });
-      await new Promise((r) => setTimeout(r, 20));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
       assert.equal(value.status.value, 'error');
       assert.deepEqual(errorReasons, ['create']);
       assert.equal(polled, false);
@@ -181,7 +199,7 @@ describe('useGlobalpingMeasurement()', () => {
     );
     try {
       value.start({}, { onError: (r) => errorReasons.push(r) });
-      await new Promise((r) => setTimeout(r, 20));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
       assert.equal(value.status.value, 'error');
       assert.deepEqual(errorReasons, ['create']);
     } finally {
@@ -205,7 +223,7 @@ describe('useGlobalpingMeasurement()', () => {
     );
     try {
       value.start({}, { onError: (r) => errorReasons.push(r) });
-      await new Promise((r) => setTimeout(r, 20));
+      await waitFor(() => value.status.value !== 'running', { label: "status to leave 'running'" });
       assert.equal(value.status.value, 'error');
       assert.deepEqual(errorReasons, ['poll']);
     } finally {
@@ -216,9 +234,13 @@ describe('useGlobalpingMeasurement()', () => {
 
   it('scope disposal before the first poll cancels pending timer and never transitions status', async () => {
     let polled = false;
+    // Set once the create response body has been read: the composable schedules
+    // the first poll immediately after that await, so this is the earliest
+    // point at which there is a pending timer for scope.stop() to cancel.
+    let createRead = false;
     stubFetch([
       [(url, init) => url === API_BASE && init?.method === 'POST',
-        () => jsonResponse({ id: 'abc' })],
+        () => ({ ok: true, status: 200, json: async () => { createRead = true; return { id: 'abc' }; } })],
       [(url) => url === `${API_BASE}/abc`,
         () => { polled = true; return jsonResponse({ status: 'finished', results: [{ ok: true }] }); }],
     ]);
@@ -233,9 +255,14 @@ describe('useGlobalpingMeasurement()', () => {
       onFinish: () => { finishCalls++; },
       onError: () => { errorCalls++; },
     });
-    // let the POST resolve but stop the scope before the poll fires
-    await new Promise((r) => setTimeout(r, 10));
+    // Stop the scope after the poll is scheduled but before it fires. A fixed
+    // 10ms sleep here could land before the POST resolved, leaving no timer to
+    // cancel — the test would then pass without exercising the cancellation.
+    await waitFor(() => createRead, { label: 'the create response to be read' });
+    await tick();
     scope.stop();
+    // Nothing should happen from here on, and only a real wait can show that:
+    // this is the one delay in the file that is asserting an absence.
     await new Promise((r) => setTimeout(r, 80));
 
     assert.equal(polled, false, 'poll should never fire after scope stop');

--- a/tests/composable-globalping-measurement.test.js
+++ b/tests/composable-globalping-measurement.test.js
@@ -247,23 +247,47 @@ describe('useGlobalpingMeasurement()', () => {
 
     let finishCalls = 0;
     let errorCalls = 0;
-    const { scope, value } = withScope(() =>
-      useGlobalpingMeasurement({ pollInterval: 50 })
-    );
-    value.start({}, {
-      onResults: () => true,
-      onFinish: () => { finishCalls++; },
-      onError: () => { errorCalls++; },
-    });
-    // Stop the scope after the poll is scheduled but before it fires. A fixed
-    // 10ms sleep here could land before the POST resolved, leaving no timer to
-    // cancel — the test would then pass without exercising the cancellation.
-    await waitFor(() => createRead, { label: 'the create response to be read' });
-    await tick();
-    scope.stop();
-    // Nothing should happen from here on, and only a real wait can show that:
-    // this is the one delay in the file that is asserting an absence.
-    await new Promise((r) => setTimeout(r, 80));
+
+    // `polled === false` alone does not pin the cancellation: onScopeDispose
+    // also sets `disposed`, and poll() returns early on that, so deleting the
+    // clearTimeout leaves every other assertion here green. Record the poll
+    // timer by its distinctive 50ms delay — tick() and waitFor() use 0 — and
+    // require that exact timer to have been cleared.
+    const origSetTimeout = globalThis.setTimeout;
+    const origClearTimeout = globalThis.clearTimeout;
+    const pollTimers = [];
+    const clearedTimers = [];
+    globalThis.setTimeout = (fn, delay, ...rest) => {
+      const id = origSetTimeout(fn, delay, ...rest);
+      if (delay === 50) pollTimers.push(id);
+      return id;
+    };
+    globalThis.clearTimeout = (id) => { clearedTimers.push(id); return origClearTimeout(id); };
+
+    try {
+      const { scope, value } = withScope(() =>
+        useGlobalpingMeasurement({ pollInterval: 50 })
+      );
+      value.start({}, {
+        onResults: () => true,
+        onFinish: () => { finishCalls++; },
+        onError: () => { errorCalls++; },
+      });
+      // Stop the scope after the poll is scheduled but before it fires. A fixed
+      // 10ms sleep here could land before the POST resolved, leaving no timer to
+      // cancel — the test would then pass without exercising the cancellation.
+      await waitFor(() => createRead, { label: 'the create response to be read' });
+      await tick();
+      assert.equal(pollTimers.length, 1, 'the first poll should be scheduled before the scope stops');
+      scope.stop();
+      assert.ok(clearedTimers.includes(pollTimers[0]), 'scope.stop() should clear the pending poll timer');
+      // Nothing should happen from here on, and only a real wait can show that:
+      // this is the one delay in the file that is asserting an absence.
+      await new Promise((r) => origSetTimeout(r, 80));
+    } finally {
+      globalThis.setTimeout = origSetTimeout;
+      globalThis.clearTimeout = origClearTimeout;
+    }
 
     assert.equal(polled, false, 'poll should never fire after scope stop');
     assert.equal(finishCalls, 0);


### PR DESCRIPTION
`tests/composable-globalping-measurement.test.js` is flaky, and one of its cases does not pin the behaviour it is named for. Both are the same underlying thing — a fixed delay standing in for a condition — so they are here together.

### The flake

Six cases asserted after a constant sleep that had to cover a POST plus up to three real `pollInterval` timers. "retries while in-progress, then finishes when the last poll returns success" allowed 80 ms for that chain:

```
await new Promise((r) => setTimeout(r, 80));
assert.equal(value.status.value, 'finished');
```

Under a loaded parallel suite that wait expires with `status === 'running'`, and the failure reads as a wrong result rather than an expired wait:

```
✖ retries while in-progress, then finishes when the last poll returns success (157.42575ms)
  AssertionError: Expected values to be strictly equal:
  + 'running'
  - 'finished'
```

Note the 157 ms body time on a test that only waits 80 ms — the process was starved, not the composable.

Measured on `dev` @ `0a0a739`, Node 26.7.0 / pnpm 11.22.0, macOS: **1 failure in 15** runs of the file alone, and it failed two of three full `pnpm check` runs. It is not a new regression — I hit it while validating an unrelated header change and A/B'd it 15 times with and without that patch, interleaved: 1 in 15 either way.

`waitFor()` polls the same observable the assertion reads, so each case takes as long as its work actually takes and its timeout only bounds a hang. Every `waitFor` here waits for `status` to leave `'running'` and then asserts the *specific* terminal state, so a wrong transition still fails on the assertion rather than being absorbed by the wait.

### The vacuous case

"scope disposal before the first poll cancels pending timer and never transitions status" asserted only `polled === false`. But `onScopeDispose` sets `disposed` as well as calling `cancel()`, and `poll()` returns early on `disposed` — so the timer firing is invisible to that assertion. Deleting the `clearTimeout` from `cancel()` left the entire test green.

Its setup was racy in the other direction too: a fixed 10 ms sleep before `scope.stop()` could land before the POST resolved, in which case there was no pending timer to cancel and the test passed without exercising cancellation at all.

It now waits for the create body to be read, asserts the poll timer was scheduled, and requires that exact timer to be among the cleared ones. The trailing 80 ms sleep stays — that one is asserting an absence, which no condition can prove.

### Validation

Mutation-checked against the composable, one mutation at a time, restoring in between:

| mutation | before | after |
| --- | --- | --- |
| never set `status = 'finished'` | 2 fail | 2 fail |
| never retry on `in-progress` | 2 fail | 2 fail |
| `onScopeDispose` no longer calls `cancel()` | **0 fail** | 1 fail |
| `cancel()` no longer clears the timer | **0 fail** | 1 fail |

- 30 consecutive runs of the file: 0 failures (was 1 in 15).
- Three consecutive full `pnpm check` runs: 1139/1139, build clean, exit 0 each time.
- The file's own runtime drops from ~0.50 s to ~0.25 s, since ~290 ms of it was fixed sleeping.

No production code changes.

AI disclosure, consistent with #442 / #445 / #446: prepared with AI assistance. I ran and reviewed every measurement and mutation above myself.
