### PR TITLE
feat(dns): add DNS.SB resolver

### DIFF
--- a/api/data/dns-resolvers.js
+++ b/api/data/dns-resolvers.js
@@ -51,4 +51,5 @@ export const DNS_RESOLVERS = [
     { id: 'giga', name: 'GIGA', country: 'TW', udp: '203.133.1.6' },
     { id: 'dns4eu', name: 'DNS4EU', country: 'EU', udp: '86.54.11.1' },
     { id: 'cznic', name: 'CZ.NIC ODVR', country: 'CZ', udp: '193.17.47.1' },
+    { id: 'dnssb', name: 'DNS.SB', country: 'EU', udp: '185.222.222.222', doh: 'https://doh.dns.sb/dns-query?' },
 ];


### PR DESCRIPTION
## Summary

This PR adds DNS.SB to the resolver registry as an EU resolver, with both UDP and JSON DoH endpoints:

- UDP: `185.222.222.222`
- DoH: `https://doh.dns.sb/dns-query?`

## Context

Issue #392 requested an additional European public resolver and specifically identified DNS.SB as a candidate. Before making this change, I verified the behavior requested in the issue:

- UDP queries return `NOERROR` responses and include the `ra` flag.
- A real nonexistent domain returns `NXDOMAIN` over UDP.
- The DoH endpoint returns HTTP 200 with a JSON DNS response and `RA: true`.
- The DoH endpoint returns DNS status `3` (`NXDOMAIN`) for a nonexistent domain.

## Raw verification excerpts

The UDP checks were run against `185.222.222.222`:

```text
$ dig +time=3 +tries=1 @185.222.222.222 example.com A
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
example.com. 259 IN A 104.20.23.154
example.com. 259 IN A 172.66.147.243

$ dig +time=3 +tries=1 @185.222.222.222 github.com A
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
github.com. 31 IN A 172.182.252.133

$ dig +time=3 +tries=1 @185.222.222.222 codex-verification-20260825.invalid A
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
```

The exact DoH request shape used by `resolveDoh` returned:

```text
GET https://doh.dns.sb/dns-query?name=example.com&type=A
Accept: application/dns-json
HTTP 200
content-type: application/json; charset=UTF-8
DNS JSON: Status=0, RD=true, RA=true
```

The same DoH request for `codex-verification-20260825.invalid` returned `Status=3` (`NXDOMAIN`).

## Effect

The registry now exposes DNS.SB as another European resolver option and supports both query paths used by MyIP. The change is limited to one resolver data entry; existing resolver behavior is unchanged.

## Verification

- `pnpm test` (1096 tests passed)
- `pnpm check` (tests and Vite production build passed)
- `git diff --check`
- Live UDP and DoH checks described above

Resolves #392.

OpenAI Codex assisted with issue review, endpoint verification, implementation, and test execution. The code and final contribution were reviewed and submitted by `fly1d`.

