### PR TITLE
Closes #408: Add the CI badge to the four READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ![PWA](https://img.shields.io/badge/PWA-Supported-blue)
 
 ![CodeQL](https://github.com/jason5ng32/MyIP/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)
+[![CI](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml/badge.svg)](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml)
 ![Docker Build and Push](https://github.com/jason5ng32/MyIP/actions/workflows/docker-image.yml/badge.svg?branch=main)
 
 [English](README.md) | [简体中文](README_ZH.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Français](README_FR.md) | [Português (BR)](README_PT-BR.md)

--- a/README_FR.md
+++ b/README_FR.md
@@ -19,6 +19,7 @@
 ![PWA](https://img.shields.io/badge/PWA-Supported-blue)
 
 ![CodeQL](https://github.com/jason5ng32/MyIP/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)
+[![CI](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml/badge.svg)](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml)
 ![Docker Build and Push](https://github.com/jason5ng32/MyIP/actions/workflows/docker-image.yml/badge.svg?branch=main)
 
 [English](README.md) | [简体中文](README_ZH.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Français](README_FR.md) | [Português (BR)](README_PT-BR.md)

--- a/README_RU.md
+++ b/README_RU.md
@@ -19,6 +19,7 @@
 ![PWA](https://img.shields.io/badge/PWA-Supported-blue)
 
 ![CodeQL](https://github.com/jason5ng32/MyIP/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)
+[![CI](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml/badge.svg)](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml)
 ![Docker Build and Push](https://github.com/jason5ng32/MyIP/actions/workflows/docker-image.yml/badge.svg?branch=main)
 
 [English](README.md) | [简体中文](README_ZH.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Français](README_FR.md) | [Português (BR)](README_PT-BR.md)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -19,6 +19,7 @@
 ![PWA](https://img.shields.io/badge/PWA-Supported-blue)
 
 ![CodeQL](https://github.com/jason5ng32/MyIP/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)
+[![CI](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml/badge.svg)](https://github.com/jason5ng32/MyIP/actions/workflows/ci.yml)
 ![Docker Build and Push](https://github.com/jason5ng32/MyIP/actions/workflows/docker-image.yml/badge.svg?branch=main)
 
 [English](README.md) | [简体中文](README_ZH.md) | [繁體中文](README_ZH_TW.md) | [Русский](README_RU.md) | [Français](README_FR.md) | [Português (BR)](README_PT-BR.md)


### PR DESCRIPTION
Closes #408.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_Kuqz9UjjWBypLfxvO-prMA -->