### PR TITLE
Add KT (Korea) public DNS resolver, closes #393

### DIFF
--- a/api/data/dns-resolvers.js
+++ b/api/data/dns-resolvers.js
@@ -52,4 +52,5 @@ export const DNS_RESOLVERS = [
     { id: 'dns4eu', name: 'DNS4EU', country: 'EU', udp: '86.54.11.1' },
     { id: 'cznic', name: 'CZ.NIC ODVR', country: 'CZ', udp: '193.17.47.1' },
     { id: 'dnssb', name: 'DNS.SB', country: 'EU', udp: '185.222.222.222', doh: 'https://doh.dns.sb/dns-query?' },
+    { id: 'kt', name: 'KT', country: 'KR', udp: '168.126.63.1' },
 ];


### PR DESCRIPTION
## What & why

Closes #393.

Adds KT (168.126.63.1) as a South Korea DNS resolver entry in api/data/dns-resolvers.js. No branded public DNS service in South Korea meets the UDP/JSON-DoH requirement, so this follows the same regional-exception precedent as #391 (Taiwan/HiNet). 

## Checklist

- [ x] Targets `dev`; one concern per PR
- [x ] `pnpm check` is green locally (tests + build)
- [ ] Logic changes ship with a spec in `tests/`
- [ ] User-visible copy lands in all five `full` locales (`en` / `zh` / `zh-TW` / `fr` / `ru`)
- [ x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the relevant `AGENTS.md`
