### PR TITLE
Feat(dns): add DNS.WATCH (Germany) resolver

### DIFF
--- a/api/data/dns-resolvers.js
+++ b/api/data/dns-resolvers.js
@@ -53,4 +53,5 @@ export const DNS_RESOLVERS = [
     { id: 'cznic', name: 'CZ.NIC ODVR', country: 'CZ', udp: '193.17.47.1' },
     { id: 'dnssb', name: 'DNS.SB', country: 'EU', udp: '185.222.222.222', doh: 'https://doh.dns.sb/dns-query?' },
     { id: 'kt', name: 'KT', country: 'KR', udp: '168.126.63.1' },
+    { id: 'dnswatch', name: 'DNS.WATCH', country: 'DE', udp: '84.200.69.80' },
 ];


### PR DESCRIPTION
Add DNS.WATCH (`84.200.69.80`, country DE) to the curated resolver list.

Public uncensored UDP resolver, documented at https://dns.watch/. Not FDN (restricted) and not Digitalcourage dns2 (their docs ask not to put that IP in new configs; dns3 is DoT-only).

Verified from outside Germany with Resolve-DnsName:
- example.com A → answers (172.66.147.243 / 104.20.23.154)
- github.com A → 140.82.121.3
- resolver-health-check.invalid A → NXDOMAIN (DNS name does not exist)

UDP only.

Related to #392
